### PR TITLE
Remove stray comma

### DIFF
--- a/src/man/syscall/_exit.html
+++ b/src/man/syscall/_exit.html
@@ -49,7 +49,7 @@ Standard C Library (libc, -lc)
 <p>
 <tt>#include &lt;unistd.h&gt;</tt><br>
 <br>
-<tt>void,</tt><br>
+<tt>void</tt><br>
 <tt>_exit(int </tt><em>exitcode</em><tt>);</tt>
 </p>
 


### PR DESCRIPTION
I removed a stray comma from the _exit prototype in the man pages.