### PR TITLE
Control-C sends SIGINT (not SIGTERM)

### DIFF
--- a/src/slides/2016/processes.adoc
+++ b/src/slides/2016/processes.adoc
@@ -233,7 +233,7 @@ received.
 send a signal to any process.
 * Processes can ignore most signals.
 ** `SIGKILL` is a notable exception; used for non-graceful termination.
-** `SIGTERM` is used for graceful shutdown and sent by Control-C.
+** `SIGTERM` is used for graceful shutdown.
 
 == !
 

--- a/src/slides/moreprocesses.adoc
+++ b/src/slides/moreprocesses.adoc
@@ -107,7 +107,7 @@ received.
 send a signal to any process.
 * Processes can ignore most signals.
 ** `SIGKILL` is a notable exception; used for non-graceful termination.
-** `SIGTERM` is used for graceful shutdown and sent by Control-C.
+** `SIGTERM` is used for graceful shutdown.
 
 == !
 


### PR DESCRIPTION
I've removed the note that Control-C sends SIGTERM since it sends SIGINT (AFAIK). Alternatively, SIGINT could be added to the list to retain the Control-C note.